### PR TITLE
change to keep staging working with new url

### DIFF
--- a/facilities/validation/gis_helper.rb
+++ b/facilities/validation/gis_helper.rb
@@ -47,7 +47,7 @@ class GISHelper
   end
 
   def self.get_layer_url(type)
-    stage = ENV['USE_PROD_GIS'] ? nil : '_stage'
+    stage = ENV['USE_PROD_GIS'] ? nil : "_stage#{'2' if type == :vha}"
     "https://services3.arcgis.com/aqgBd3l68G8hEFFE/ArcGIS/rest/services/#{FACILITY_TYPES[type]}#{stage}/FeatureServer/0"
   end
 


### PR DESCRIPTION
geoBISL had to change the staging url a few weeks ago .. doesn't affect prod and we only use staging for data validation. This change is to keep this validation script working with staging data.